### PR TITLE
Modification de la rom pour qu'elle puisse être lu par le kernel.

### DIFF
--- a/src/Orix.s
+++ b/src/Orix.s
@@ -56,9 +56,10 @@
 		;
 		; ----------------------------------------------------------------------------
 		        .word   parse_routine
-		        .word   0
-		        .word   0
-		        .byte   0
+		        .addr   $fffc
+		        .addr   parse_cmd
+				; $FFF7
+		        .byte   1 ; Number of commands in this rom
 
 	.endif
 


### PR DESCRIPTION
Le vector de parse pourrait sauter car il n'est plus appelé désormais

En $fff7, c'est le nombre de commande que la ROM a 

En $fff5-$fff6, c'est le pointer vers la liste des functions 

En $fff3-$fff4, c'est l'adresse qui pointe sur la liste d'adresse des commandes. Comme il n'y a qu'une commande $fffc suffit