### PR TITLE
Suppression du parse de la ligne de commande car le kernel (primitive…

### DIFF
--- a/src/Orix.s
+++ b/src/Orix.s
@@ -10,36 +10,8 @@
 		Included::ORIX_INC = 1
 		verbose 3, "Ajout compatibilité Orix (exec)"
 
-
-		; ----------------------------------------------------------------------------
-		; Compatibilité Orix: exec
-		; ----------------------------------------------------------------------------
-		BUFEDT = $0590
-
-		.proc parse_routine
-		        ldy #$ff
-
-		@loop:
-		        iny
-		        lda BUFEDT,y
-		        beq @maybe
-		        cmp parse_cmd,y
-		        beq @loop
-		        cmp #' '
-		        bne @not_found
-
-		@maybe:
-		        lda parse_cmd,y
-		        bne @not_found
-		        jmp ($fffc)
-
-		@not_found:
-		        rts
-		.endproc
-
 		parse_cmd:
 		        .asciiz "forth"
-
 
 	.else
 		; verbose 3, "Ajout vecteurs Orix (exec)"
@@ -55,10 +27,11 @@
 		; ----------------------------------------------------------------------------
 		;
 		; ----------------------------------------------------------------------------
-		        .word   parse_routine
-		        .word   0
-		        .word   0
-		        .byte   0
+		        .word   $0000
+		        .addr   $fffc
+		        .addr   parse_cmd
+				; $FFF7
+		        .byte   1 ; Number of commands in this rom
 
 	.endif
 


### PR DESCRIPTION
… XEXEC) via le shell peut désormais executer la commande directement sans appeler la routine de parse de chaque ROM